### PR TITLE
Add "in or to"

### DIFF
--- a/index.json
+++ b/index.json
@@ -53,6 +53,7 @@
   "in favor": "for",
   "initiate": "start",
   "in opposition to": "against",
+  "in or to": "to",
   "in order that": "so",
   "in order to": "to",
   "in preference to": "over",


### PR DESCRIPTION
This PR adds "in or to", suggesting instead simply "to".

This comes up in IP licensing pretty often. For example: 

> Without limitation, this <Agreement> grants you no rights **in or to** the intellectual property of [Company Name Short] or any other party, except as expressly set forth herein.

I don't think Ken Adams has addressed this one, although I may have missed it.

Any thoughts, @kemitchell? Are you aware of any valid legal reason for using "in or to" over "to"?
